### PR TITLE
Fix when used with multiple pages in a row

### DIFF
--- a/src/MetaTags.php
+++ b/src/MetaTags.php
@@ -17,6 +17,7 @@ class MetaTags
     protected $indentation;
     protected $order;
     protected $page;
+    protected $data;
 
     public function __construct(Page $page)
     {
@@ -65,13 +66,18 @@ class MetaTags
     *
     * @param  Page  $page
     *
-    * @return HeadTags
+    * @return MetaTags
     */
     public static function instance($page)
     {
-        return static::$instance = is_null(static::$instance)
+        $instance = is_null(static::$instance)
             ? new static($page)
             : static::$instance;
+        if ($instance->page !== $page) {
+            $instance = new static($page);
+        }
+
+        return static::$instance = $instance;
     }
 
     public function render($groups = null)


### PR DESCRIPTION
While everything works great with a single page, tags are duplicated when the plugin is used with multiple pages in a row, e.g. with the static site generator plugin.
This PR checks if the static instance is for the same page, and if not, returns a new instance, which fixes the duplicated tags issue. See also https://github.com/d4l-data4life/kirby3-static-site-generator/issues/21