### PR TITLE
Bugfix: Fix PHP8.2 compatibility

### DIFF
--- a/src/MetaTags.php
+++ b/src/MetaTags.php
@@ -17,6 +17,7 @@ class MetaTags
     protected $indentation;
     protected $order;
     protected $page;
+    protected $data;
 
     public function __construct(Page $page)
     {


### PR DESCRIPTION
`$data` on line 47 is not defined and therefore gives an error on PHP8.2. This fixes the following error:

```An exception has been thrown during the rendering of a template ("Creation of dynamic property PedroBorges\KirbyMetaTags\MetaTags::$data is deprecated").```